### PR TITLE
Add message about tiebreaker fix

### DIFF
--- a/mlbpool/templates/picks/submit-picks.pt
+++ b/mlbpool/templates/picks/submit-picks.pt
@@ -195,7 +195,8 @@
 
                         <h3>Tiebreaker</h3>
                         <p>How many wins will the Minnesota Twins finish with?</p>
-                        <p><b>You cannot make any changes to your tiebreaker pick!</b></p>
+                        <p><b>Choose the number of wins from the drop down menu below.
+                            You cannot make any changes to your tiebreaker pick!</b></p>
                         <select class="form-control" name="twins_wins_pick">
                             <option tal:repeat="a twins_wins_pick_list" value="${a}">${a} </option>
                         </select>


### PR DESCRIPTION
Users are skipping the tiebreaker pick from the drop down menu.  Add
text to tell them to pay attention.